### PR TITLE
Fix: add env validation

### DIFF
--- a/types/views/address.ts
+++ b/types/views/address.ts
@@ -1,10 +1,26 @@
 import type { ArrayElement } from 'types/utils';
 
-export const IDENTICON_TYPES = [
+export const SINGLE_IDENTICON_TYPES = [
   'github',
   'jazzicon',
   'gradient_avatar',
   'blockie',
+] as const;
+
+export const makeUniversalProfileIdenticonsUnions = () => {
+  const upUnions = SINGLE_IDENTICON_TYPES.map((identicon) => {
+    return `universal_profile|${ identicon }`;
+  });
+
+  return [
+    ...SINGLE_IDENTICON_TYPES,
+    ...upUnions,
+  ];
+};
+
+export const IDENTICON_TYPES = [
+  ...SINGLE_IDENTICON_TYPES,
+  ...makeUniversalProfileIdenticonsUnions(),
 ] as const;
 
 export type IdenticonType = ArrayElement<typeof IDENTICON_TYPES>;

--- a/types/views/address.ts
+++ b/types/views/address.ts
@@ -8,14 +8,9 @@ export const SINGLE_IDENTICON_TYPES = [
 ] as const;
 
 export const makeUniversalProfileIdenticonsUnions = () => {
-  const upUnions = SINGLE_IDENTICON_TYPES.map((identicon) => {
+  return SINGLE_IDENTICON_TYPES.map((identicon) => {
     return `universal_profile|${ identicon }`;
   });
-
-  return [
-    ...SINGLE_IDENTICON_TYPES,
-    ...upUnions,
-  ];
 };
 
 export const IDENTICON_TYPES = [


### PR DESCRIPTION
This PR fixes an issue where the universal_profile|identicon env value is not accepted by the env validator 