### PR TITLE
Feature: Adjust address view

### DIFF
--- a/lib/shortenUniversalProfile.ts
+++ b/lib/shortenUniversalProfile.ts
@@ -7,8 +7,8 @@ export default function shortenUniversalProfile(string: string | null) {
     return string;
   }
 
-  const upParts = string.split('#');
-  const hashHead = '#' + upParts[1].slice(2, 6); // change #0x1234 -> #1234
+  const upParts = string.split(' (');
+  const hashHead = '#' + upParts[1].slice(2, 6); // change (0x1234) -> #1234
 
-  return string.slice(0, 3) + '...' + hashHead;
+  return string.slice(0, 2) + '...' + hashHead;
 }

--- a/ui/shared/HashStringShorten.tsx
+++ b/ui/shared/HashStringShorten.tsx
@@ -20,7 +20,7 @@ const HashStringShorten = ({ hash, isTooltipDisabled, as = 'span' }: Props) => {
     if (identiconType === undefined) {
       return undefined;
     }
-    if (identiconType.includes('universal_profile') && hash.includes('#')) {
+    if (identiconType.includes('universal_profile') && hash.includes(' (')) {
       setShortenedString(shortenUniversalProfile(hash));
     }
   }, [ hash ]);

--- a/ui/shared/HashStringShortenDynamic.tsx
+++ b/ui/shared/HashStringShortenDynamic.tsx
@@ -73,12 +73,12 @@ const HashStringShortenDynamic = ({ hash, fontWeight = '400', isTooltipDisabled,
       if (identiconType === undefined) {
         return;
       }
-      if (identiconType.includes('universal_profile') && hash.includes('#')) {
-        const upParts = hash.split('#');
-        const hashHead = '#' + upParts[1].slice(2, 6); // change #0x1234 -> #1234
+      if (identiconType.includes('universal_profile') && hash.includes(' (')) {
+        const upParts = hash.split(' (');
+        const hashHead = '#' + upParts[1].slice(2, 6); // change (0x1234...5678) -> #1234
         const name = upParts[0];
-        const slicedName = name.slice(0, rightI - 2);
-        const displayed = rightI - 2 > name.length ? name + hashHead : slicedName + '...' + hashHead;
+        const slicedName = name.slice(0, rightI - 3);
+        const displayed = rightI - 3 > name.length ? name + hashHead : slicedName + '...' + hashHead;
         setDisplayedString(displayed);
 
         return;

--- a/ui/shared/entities/address/IdenticonUniversalProfileQuery.tsx
+++ b/ui/shared/entities/address/IdenticonUniversalProfileQuery.tsx
@@ -13,7 +13,7 @@ interface Props {
 }
 
 export const formattedLuksoName = (hash: string, name: string) => {
-  return `@${ name }#${ hash }`;
+  return `@${ name } (${ hash })`;
 };
 
 export const getUniversalProfile = async(address: string, queryClient: QueryClient) => {


### PR DESCRIPTION
This PR includes some small adjustments for the long `Universal Profile` display.

Change list:
- [X] Changed Universal Profile display text (details below)

Old text: `example#0x1234...5678`

New text (images below):
![image](https://github.com/lukso-network/network-explorer-execution-frontend/assets/44748271/ca47bb9c-851e-42cb-a4ef-a179b76c3399)
![image](https://github.com/lukso-network/network-explorer-execution-frontend/assets/44748271/36023950-6853-49c3-97e9-488d0f31832c)
