### PR TITLE
Fix/thinking aloud

### DIFF
--- a/ui/shared/entities/address/IdenticonUniversalProfileQuery.tsx
+++ b/ui/shared/entities/address/IdenticonUniversalProfileQuery.tsx
@@ -45,9 +45,9 @@ export const IdenticonUniversalProfile: React.FC<Props> = ({
   address,
   fallbackIcon,
 }) => {
-  const { data: up } = useUniversalProfile(address);
+  const { data: up, isLoading } = useUniversalProfile(address);
 
-  if (up === undefined || up.LSP3Profile === undefined) {
+  if (isLoading || !up || !up.LSP3Profile) {
     return fallbackIcon;
   }
 


### PR DESCRIPTION
## Description and Related Issue(s)

Caching for api.universalprofile.cloud is not ideal and the browser many times tries
to get information for the same address due to useEffect and useState re-rendering.

### Proposed Changes

Change to use useQuery instead of manually using the query client.

### Additional Information

The change should be observable in the network panel of the browser debugger.

## Checklist for PR author

- [ ] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable, I have updated the list of environment variables in the [documentation](ENVS.md) and made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)