### PR TITLE
feat: Remove unit from gas limit

### DIFF
--- a/ui/tx/internals/TxInternalsTable.tsx
+++ b/ui/tx/internals/TxInternalsTable.tsx
@@ -37,7 +37,7 @@ const TxInternalsTable = ({ data, sort, onSortToggle, top, isLoading }: Props) =
             <Th width="16%" isNumeric>
               <Link display="flex" alignItems="center" justifyContent="flex-end" onClick={ onSortToggle('gas-limit') } columnGap={ 1 }>
                 { sort?.includes('gas-limit') && <IconSvg name="arrows/east" boxSize={ 4 } transform={ sortIconTransform }/> }
-                Gas limit { currencyUnits.ether }
+                Gas limit
               </Link>
             </Th>
           </Tr>


### PR DESCRIPTION
This PR removes a unit from the `Gas Limit` tab of the transaction details.
![image](https://github.com/lukso-network/network-explorer-execution-frontend/assets/44748271/d26bf5ff-b8c0-4a47-9b09-37bedc7b0772)
