### PR TITLE
feat: Correct wording for sending LYX

### DIFF
--- a/ui/address/contract/methodForm/ContractMethodForm.tsx
+++ b/ui/address/contract/methodForm/ContractMethodForm.tsx
@@ -73,7 +73,7 @@ const ContractMethodForm = <T extends SmartContractMethod>({ data, onSubmit, res
     return [
       ...('inputs' in data ? data.inputs : []),
       ...('stateMutability' in data && data.stateMutability === 'payable' ? [ {
-        name: `Send native ${ config.chain.currency.symbol || 'coin' }`,
+        name: `Send native ${ config.chain.currency.symbol || 'coin' } in WEI`,
         type: 'uint256' as const,
         internalType: 'uint256' as const,
         fieldType: 'native_coin' as const,


### PR DESCRIPTION
This PR rewords a field that confusingly doesn't actually send any LYX, but rather sends WEI that you can ultiply to be LYX