### PR TITLE
fix: Truncate proxy entries

### DIFF
--- a/ui/shared/entities/address/AddressEntityContentProxy.tsx
+++ b/ui/shared/entities/address/AddressEntityContentProxy.tsx
@@ -6,11 +6,15 @@ import * as EntityBase from 'ui/shared/entities/base/components';
 
 import type { ContentProps } from './AddressEntity';
 import AddressEntity from './AddressEntity';
+import { formattedLuksoName, useUniversalProfile } from './IdenticonUniversalProfileQuery';
 
 const AddressEntityContentProxy = (props: ContentProps) => {
   const bgColor = useColorModeValue('gray.700', 'gray.900');
 
   const implementations = props.address.implementations;
+
+  const { data: upData, isLoading: upIsLoading } = useUniversalProfile(props.address.hash);
+  const upName = upIsLoading ? '' : upData?.name ?? '';
 
   const handleClick = React.useCallback((event: React.MouseEvent) => {
     event.stopPropagation();
@@ -25,14 +29,19 @@ const AddressEntityContentProxy = (props: ContentProps) => {
 
   const implementationName = implementations.length === 1 && implementations[0].name ? implementations[0].name : undefined;
 
+  const fallback = nameTag || implementationName || props.address.name || props.address.hash;
+  const displayedText = upName !== '' ? formattedLuksoName(props.address.hash, upName) : fallback;
+  const truncation = nameTag || implementationName || props.address.name ? 'tail' : props.truncation;
+  const upTruncation = upName !== '' ? 'dynamic' : truncation;
+
   return (
     <Popover trigger="hover" isLazy gutter={ 8 }>
       <PopoverTrigger>
         <Box display="inline-flex" w="100%">
           <EntityBase.Content
             { ...props }
-            truncation={ nameTag || implementationName || props.address.name ? 'tail' : props.truncation }
-            text={ nameTag || implementationName || props.address.name || props.address.hash }
+            truncation={ upTruncation }
+            text={ displayedText }
             isTooltipDisabled
           />
         </Box>

--- a/ui/shared/entities/address/IdenticonUniversalProfileQuery.tsx
+++ b/ui/shared/entities/address/IdenticonUniversalProfileQuery.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 
 import { graphClient } from 'lib/api/graphClient';
 import type { SearchProfileQueryResponse } from 'lib/api/graphTypes';
+import { isUniversalProfileEnabled } from 'lib/api/isUniversalProfileEnabled';
 
 interface Props {
   address: string;
@@ -14,6 +15,10 @@ interface Props {
 
 const profiles = create({
   fetcher: async(addresses: Array<string>) => {
+    if (!isUniversalProfileEnabled()) {
+      return [] as Array<SearchProfileQueryResponse>;
+    }
+
     const resp = await graphClient.getProfiles(JSON.stringify(addresses));
     if (resp === null) {
       return [] as Array<SearchProfileQueryResponse>;

--- a/ui/shared/entities/base/components.tsx
+++ b/ui/shared/entities/base/components.tsx
@@ -117,7 +117,6 @@ export interface ContentBaseProps extends Pick<EntityBaseProps, 'className' | 'i
 }
 
 const Content = chakra(({ className, isLoading, asProp, text, truncation = 'dynamic', tailLength, isTooltipDisabled }: ContentBaseProps) => {
-
   const children = (() => {
     switch (truncation) {
       case 'constant_long':


### PR DESCRIPTION
## Description and Related Issue(s)

This PR fixes a bug where profile names appeared as contract proxies instead of the profile names.
Before:
![image](https://github.com/user-attachments/assets/4ae53d6d-17f1-4b59-9341-c816f35ff18d)

After:
![image](https://github.com/user-attachments/assets/9d3918b5-e184-4342-9e19-a71da325fda9)

### Proposed Changes
Added a truncation for proxy text. Also added a check for enabled universal profiles before fetching

### Breaking or Incompatible Changes
*[Describe any breaking or incompatible changes introduced by this pull request. Specify how users might need to modify their code or configurations to accommodate these changes.]*

### Additional Information
*[Include any additional information, context, or screenshots that may be helpful for reviewers.]*

## Checklist for PR author
- [X] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
