### PR TITLE
fix: profile picture styling

### DIFF
--- a/ui/shared/Page/PageTitle.tsx
+++ b/ui/shared/Page/PageTitle.tsx
@@ -154,7 +154,7 @@ const PageTitle = ({ title, contentAfter, withTextAd, backLink, className, isLoa
         { withTextAd && <TextAd order={{ base: -1, lg: 100 }} mb={{ base: 6, lg: 0 }} ml="auto" w={{ base: '100%', lg: 'auto' }}/> }
       </Flex>
       { secondRow && (
-        <Flex alignItems="center" minH={ 10 } overflow="hidden" _empty={{ display: 'none' }}>
+        <Flex alignItems="center" minH={ 10 } _empty={{ display: 'none' }}>
           { secondRow }
         </Flex>
       ) }

--- a/ui/shared/entities/address/IdenticonUniversalProfileQuery.tsx
+++ b/ui/shared/entities/address/IdenticonUniversalProfileQuery.tsx
@@ -74,9 +74,9 @@ export const IdenticonUniversalProfile: React.FC<Props> = ({
   }
 
   return (
-    <Skeleton mr={ profileImageUrl ? 2 : 0 } isLoaded={ !isLoading }>
+    <Skeleton pr={ profileImageUrl ? 1.5 : 0 } isLoaded={ !isLoading }>
       { profileImageUrl ? (
-        <Box style={{ transform: 'scale(0.8)' }} ml={ -0.25 }>
+        <Box style={{ transform: 'scale(0.8)', zIndex: 1000 }} zIndex={ 1000 } ml={ -0.5 }>
           <lukso-profile
             size="x-small"
             profile-url={ profileImageUrl }

--- a/ui/shared/entities/address/IdenticonUniversalProfileQuery.tsx
+++ b/ui/shared/entities/address/IdenticonUniversalProfileQuery.tsx
@@ -74,9 +74,9 @@ export const IdenticonUniversalProfile: React.FC<Props> = ({
   }
 
   return (
-    <Skeleton isLoaded={ !isLoading }>
+    <Skeleton mr={ profileImageUrl ? 2 : 0 } isLoaded={ !isLoading }>
       { profileImageUrl ? (
-        <Box mx={ 2 }>
+        <Box style={{ transform: 'scale(0.8)' }} ml={ -0.25 }>
           <lukso-profile
             size="x-small"
             profile-url={ profileImageUrl }


### PR DESCRIPTION
## Description and Related Issue(s)

Since [`lukso-profile`](https://www.npmjs.com/package/@lukso/web-components) web components differed in styling from the blockscout icon components, there was a lot of differences visible in the UI. This PR aims to minimize this effect.

### Proposed Changes
- Added styling to LUKSO-specific components.

### Additional Information
New desktop views
![image](https://github.com/user-attachments/assets/5685ac7b-a07d-4090-895b-13b1b40e1042)
![image](https://github.com/user-attachments/assets/afdea289-0b0e-4cdc-8d3e-8d75e7e7f7fd)
![image](https://github.com/user-attachments/assets/3e8af388-1300-4b55-9509-c27bc58b0e8a)

New mobile views
![image](https://github.com/user-attachments/assets/a646c8d9-0a2c-4ee5-b555-753763d0fcc7)
![image](https://github.com/user-attachments/assets/8b61c858-20e9-4243-b4fd-5bc285d9b4f9)


## Checklist for PR author
- [X] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
