### PR TITLE
fix: Reword total supply labels

### DIFF
--- a/ui/token/TokenDetails.tsx
+++ b/ui/token/TokenDetails.tsx
@@ -138,7 +138,7 @@ const TokenDetails = ({ tokenQuery }: Props) => {
         hint="The total amount of tokens issued"
         isLoading={ tokenQuery.isPlaceholderData }
       >
-        { type === "LSP7" || type === "LSP8" ? "Current total supply" : "Max total supply" }
+        Current total supply
       </DetailedInfo.ItemLabel>
       <DetailedInfo.ItemValue
         alignSelf="center"

--- a/ui/token/TokenDetails.tsx
+++ b/ui/token/TokenDetails.tsx
@@ -138,7 +138,7 @@ const TokenDetails = ({ tokenQuery }: Props) => {
         hint="The total amount of tokens issued"
         isLoading={ tokenQuery.isPlaceholderData }
       >
-        Max total supply
+        { type === "LSP7" || type === "LSP8" ? "Current total supply" : "Max total supply" }
       </DetailedInfo.ItemLabel>
       <DetailedInfo.ItemValue
         alignSelf="center"


### PR DESCRIPTION
This PR rewords the total supply label so that it's not misleading for LUKSO users